### PR TITLE
Fix EC certificate detection for OpenSSL variants

### DIFF
--- a/clone-cert.sh
+++ b/clone-cert.sh
@@ -405,7 +405,7 @@ function clone_cert () {
 
     OLD_MODULUS="$(openssl x509 -in "$CERT" -modulus -noout \
         | sed -e 's/Modulus=//' | tr "[:upper:]" "[:lower:]")"
-    if [[ $OLD_MODULUS = "wrong algorithm type" ]] ; then
+    if [[ $OLD_MODULUS = "wrong algorithm type" || $OLD_MODULUS = "no modulus for this public key type" ]] ; then
         # it's EC and not RSA (or maybe DSA...)
         SCHEME=ec
         offset="$(openssl x509 -in "$CERT" -pubkey -noout 2> /dev/null \


### PR DESCRIPTION
# Pull Request: Fix EC certificate detection for OpenSSL variants

## Description
This PR fixes an issue with EC certificate detection in the `clone-cert.sh` script. The script currently only detects EC certificates when OpenSSL returns "wrong algorithm type" when attempting to extract the modulus. However, some OpenSSL variants (depending on version or distribution) return "no modulus for this public key type" instead, causing the script to incorrectly process EC certificates as RSA.

## The Fix
Modified the condition that checks for EC certificates to handle both error message variants:
```bash
if [[ $OLD_MODULUS = "wrong algorithm type" || $OLD_MODULUS = "no modulus for this public key type" ]] ; then
    # it's EC and not RSA (or maybe DSA...)
    SCHEME=ec
```

## Background
Different OpenSSL implementations/versions can return slightly different error messages when attempting to extract the modulus from an EC key. This change makes the script more robust by accepting either known error message variant.