### PR TITLE
Fix handling of certificates without Authority Key Identifier

### DIFF
--- a/clone-cert.sh
+++ b/clone-cert.sh
@@ -348,8 +348,13 @@ function extract-values () {
     AUTH_KEY_IDENTIFIER="$(openssl asn1parse -in "$CERT" \
         | grep -A1 ":X509v3 Authority Key Identifier" | tail -n1 \
         | sed 's/.*\[HEX DUMP\]://' \
-        | sed 's/^.\{8\}//')"
-    debug "Original AuthKeyIdentifier: $AUTH_KEY_IDENTIFIER"
+        | sed 's/^.\{8\}//')"    
+    if [[ -z "$AUTH_KEY_IDENTIFIER" ]]; then    
+        AUTH_KEY_IDENTIFIER="$(openssl rand -hex 20)"
+        debug "Generated random AuthKeyIdentifier: $AUTH_KEY_IDENTIFIER"
+    else
+        debug "Original AuthKeyIdentifier: $AUTH_KEY_IDENTIFIER"
+    fi
 }
 
 function create-fake-CA () {


### PR DESCRIPTION
This PR fixes an issue where clone-cert.sh fails when cloning certificates without an Authority Key Identifier extension. Happened with a IoT Device